### PR TITLE
Add time bank

### DIFF
--- a/base/src/errors.rs
+++ b/base/src/errors.rs
@@ -48,3 +48,5 @@ custom_err!(flop_cards_error);
 custom_err!(turn_card_error);
 custom_err!(river_card_error);
 custom_err!(wait_timeout_error_in_settle);
+custom_err!(time_card_already_in_use);
+custom_err!(no_time_cards);

--- a/base/src/essential.rs
+++ b/base/src/essential.rs
@@ -5,7 +5,7 @@ use race_api::prelude::{CustomEvent, HandleError};
 use std::collections::BTreeMap;
 
 pub const MAX_ACTION_TIMEOUT_COUNT: u8 = 2;
-pub const ACTION_TIMEOUT_PREFLOP: u64 = 12_000;
+pub const ACTION_TIMEOUT_PREFLOP: u64 = 7_000;
 pub const ACTION_TIMEOUT_POSTFLOP: u64 = 15_000;
 pub const ACTION_TIMEOUT_TURN: u64 = 20_000;
 pub const ACTION_TIMEOUT_RIVER: u64 = 30_000;
@@ -15,7 +15,8 @@ pub const WAIT_TIMEOUT_LAST_PLAYER: u64 = 5_000;
 pub const WAIT_TIMEOUT_SHOWDOWN: u64 = 10_000;
 pub const WAIT_TIMEOUT_RUNNER: u64 = 13_000;
 
-pub const RAKE_SLOT_ID: u8 = 0;
+pub const TIME_CARD_EXTRA_SECS: u64 = 30;
+pub const DEFAULT_TIME_CARDS: u8 = 5;
 
 /// Holdem Modes in which a specific table type is defined
 #[derive(BorshSerialize, BorshDeserialize, Default, PartialEq, Debug, Clone, Copy)]
@@ -57,9 +58,16 @@ pub struct Player {
     pub status: PlayerStatus,
     pub timeout: u8,  // count the times of action timeout
     pub deposit: u64, // The deposited amount
+    pub time_cards: u8, // The number of time cards, each gives extra TIME_CARD_EXTRA_SECS for action.
 }
 
 impl Player {
+    pub fn new(id: u64, chips: u64, position: u16, status: PlayerStatus, timeout: u8, deposit: u64, time_cards: u8) -> Player {
+        Self {
+            id, chips, position: position as usize, status, timeout, deposit, time_cards
+        }
+    }
+
     pub fn new_with_timeout(id: u64, chips: u64, position: u16, timeout: u8) -> Player {
         Self {
             id,
@@ -68,6 +76,7 @@ impl Player {
             status: PlayerStatus::default(),
             timeout,
             deposit: 0,
+            time_cards: DEFAULT_TIME_CARDS,
         }
     }
 
@@ -84,6 +93,7 @@ impl Player {
             status,
             timeout: 0,
             deposit: 0,
+            time_cards: DEFAULT_TIME_CARDS,
         }
     }
 
@@ -95,6 +105,7 @@ impl Player {
             status: PlayerStatus::Init,
             timeout: 0,
             deposit: 0,
+            time_cards: DEFAULT_TIME_CARDS,
         }
     }
 
@@ -136,7 +147,19 @@ impl Player {
 pub struct ActingPlayer {
     pub id: u64,
     pub position: usize,
+    pub action_start: u64,
     pub clock: u64, // action clock
+    pub time_card_clock: Option<u64>, // Some when a time card is in use
+}
+
+impl ActingPlayer {
+    pub fn new(id: u64, position: usize, action_start: u64, clock: u64) -> ActingPlayer {
+        Self { id, position, action_start, clock, time_card_clock: None }
+    }
+
+    pub fn new_with_time_card(id: u64, position: usize, action_start: u64, clock: u64) -> ActingPlayer {
+        Self { id, position, action_start, clock, time_card_clock: Some(clock + TIME_CARD_EXTRA_SECS * 1000) }
+    }
 }
 
 /// Representation of Holdem pot
@@ -222,6 +245,7 @@ pub enum GameEvent {
     Fold,
     Raise(u64),
     SitOut,
+    UseTimeCard, // Activate a time card, the time card will only be consumed when the extra time is used.
 }
 
 impl CustomEvent for GameEvent {}

--- a/base/src/essential.rs
+++ b/base/src/essential.rs
@@ -80,7 +80,9 @@ impl Player {
         }
     }
 
-    pub fn new_with_timeout_and_status(
+    /// Give timeout, deposit and time_cards a default value.
+    /// For testing.
+    pub fn new_with_defaults(
         id: u64,
         chips: u64,
         position: usize,

--- a/base/src/game.rs
+++ b/base/src/game.rs
@@ -5,10 +5,7 @@ use std::mem::take;
 
 use crate::errors;
 use crate::essential::{
-    ActingPlayer, AwardPot, Display, GameEvent, GameMode, HoldemAccount, HoldemStage,
-    InternalPlayerJoin, Player, PlayerResult, PlayerStatus, Pot, Street, ACTION_TIMEOUT_POSTFLOP,
-    ACTION_TIMEOUT_PREFLOP, ACTION_TIMEOUT_RIVER, ACTION_TIMEOUT_TURN, MAX_ACTION_TIMEOUT_COUNT,
-    WAIT_TIMEOUT_DEFAULT,
+    ActingPlayer, AwardPot, Display, GameEvent, GameMode, HoldemAccount, HoldemStage, InternalPlayerJoin, Player, PlayerResult, PlayerStatus, Pot, Street, ACTION_TIMEOUT_POSTFLOP, ACTION_TIMEOUT_PREFLOP, ACTION_TIMEOUT_RIVER, ACTION_TIMEOUT_TURN, MAX_ACTION_TIMEOUT_COUNT, TIME_CARD_EXTRA_SECS, WAIT_TIMEOUT_DEFAULT, WAIT_TIMEOUT_LAST_PLAYER, WAIT_TIMEOUT_RUNNER, WAIT_TIMEOUT_SHOWDOWN
 };
 use crate::evaluator::{compare_hands, create_cards, evaluate_cards, PlayerHand};
 use crate::hand_history::{BlindBet, BlindType, HandHistory, PlayerAction, Showdown};
@@ -271,6 +268,20 @@ impl Holdem {
         }
     }
 
+    pub fn set_action_timeout(&mut self, effect: &mut Effect) -> Result<(), HandleError> {
+        let Some(ref acting_player) = self.acting_player else {
+            return Err(errors::internal_cannot_find_action_player())?;
+        };
+        if let Some(t) = acting_player.time_card_clock {
+            effect.info("Set player action timeout according to time card timeout");
+            effect.action_timeout(acting_player.id, t.saturating_sub(effect.timestamp()))?;
+        } else {
+            effect.info("Set player action timeout according to normal timeout");
+            effect.action_timeout(acting_player.id, acting_player.clock.saturating_sub(effect.timestamp()))?;
+        }
+        Ok(())
+    }
+
     pub fn ask_for_action(
         &mut self,
         player_id: u64,
@@ -280,12 +291,10 @@ impl Holdem {
         if let Some(player) = self.player_map.get_mut(&player_id) {
             effect.info(format!("Asking {} to act", player.id));
             player.status = PlayerStatus::Acting;
-            self.acting_player = Some(ActingPlayer {
-                id: player.id,
-                position: player.position,
-                clock: effect.timestamp() + timeout,
-            });
-            effect.action_timeout(player_id, timeout)?; // in msecs
+            let action_start = effect.timestamp();
+            let clock = action_start + timeout;
+            self.acting_player = Some(ActingPlayer::new(player.id, player.position, action_start, clock));
+            self.set_action_timeout(effect)?;
             Ok(())
         } else {
             return Err(errors::next_action_player_missing());
@@ -1035,7 +1044,58 @@ impl Holdem {
         }
     }
 
-    pub fn handle_custom_event(
+    pub fn handle_custom_event(&mut self, effect: &mut Effect, event: GameEvent, sender: u64) -> Result<(), HandleError> {
+        match event {
+            GameEvent::Bet(_) | GameEvent::Check | GameEvent::Fold | GameEvent::Raise(_) | GameEvent::Call => {
+                return self.handle_action_event(effect, event, sender);
+            }
+
+            GameEvent::SitOut => {
+                self.set_player_status(sender, PlayerStatus::Leave)?;
+                let _ = self.handle_player_leave(effect, sender);
+                Ok(())
+            }
+
+            GameEvent::UseTimeCard => {
+                let Some(ref mut acting_player) = self.acting_player else {
+                    return Err(errors::not_the_acting_player())?;
+                };
+                if acting_player.id != sender {
+                    return Err(errors::not_the_acting_player())?;
+                }
+                let Some(ref player) = self.player_map.get(&sender) else {
+                    return Err(HandleError::InvalidPlayer);
+                };
+                if player.time_cards == 0 {
+                    return Err(errors::no_time_cards())?;
+                }
+                if acting_player.time_card_clock.is_some() {
+                    return Err(errors::time_card_already_in_use())?;
+                }
+                acting_player.time_card_clock = Some(acting_player.clock + TIME_CARD_EXTRA_SECS * 1000);
+                self.set_action_timeout(effect)?;
+                Ok(())
+            }
+        }
+    }
+
+    pub fn reduce_time_cards(&mut self, effect: &mut Effect) -> Result<(), HandleError> {
+        let Some(ref acting_player) = self.acting_player else {
+            return Err(errors::internal_cannot_find_action_player())?;
+        };
+        // When the player used at least one time card
+        if acting_player.time_card_clock.is_some() && effect.timestamp() > acting_player.clock {
+            let extra_time_cost = effect.timestamp() -  acting_player.clock;
+            let time_card_used = extra_time_cost / (TIME_CARD_EXTRA_SECS * 1000) + 1;
+            let Some(player) = self.player_map.get_mut(&acting_player.id) else {
+                return Err(errors::internal_player_not_found())?;
+            };
+            player.time_cards -= time_card_used as u8;
+        }
+        Ok(())
+    }
+
+    pub fn handle_action_event(
         &mut self,
         effect: &mut Effect,
         event: GameEvent,
@@ -1067,6 +1127,7 @@ impl Holdem {
                 self.set_player_acted(sender, allin)?;
                 self.min_raise = amount;
                 self.street_bet = amount;
+                self.reduce_time_cards(effect)?;
             }
 
             GameEvent::Call => {
@@ -1078,6 +1139,7 @@ impl Holdem {
                 let call_amount = self.street_bet - betted;
                 let (allin, _) = self.take_bet(sender.clone(), call_amount)?;
                 self.set_player_acted(sender, allin)?;
+                self.reduce_time_cards(effect)?;
             }
 
             GameEvent::Check => {
@@ -1091,6 +1153,7 @@ impl Holdem {
                     return Err(errors::player_cant_check());
                 }
                 self.set_player_status(sender, PlayerStatus::Acted)?;
+                self.reduce_time_cards(effect)?;
             }
 
             GameEvent::Fold => {
@@ -1098,6 +1161,7 @@ impl Holdem {
                     return Err(errors::not_the_acting_player_to_fold());
                 }
                 self.set_player_status(sender, PlayerStatus::Fold)?;
+                self.reduce_time_cards(effect)?;
             }
 
             GameEvent::Raise(amount) => {
@@ -1119,6 +1183,7 @@ impl Holdem {
                 let new_min_raise = new_street_bet - self.street_bet;
                 self.street_bet = new_street_bet;
                 self.min_raise = new_min_raise;
+                self.reduce_time_cards(effect)?;
             }
 
             _ => {}
@@ -1396,14 +1461,8 @@ impl GameHandler for Holdem {
                     event, sender
                 ));
 
-                match event {
-                    GameEvent::SitOut => {
-                        self.set_player_status(sender, PlayerStatus::Leave)?;
-                        let _ = self.handle_player_leave(effect, sender);
-                    }
 
-                    _ => self.handle_custom_event(effect, event, sender)?,
-                }
+                self.handle_custom_event(effect, event, sender)?;
 
                 Ok(())
             }
@@ -1412,6 +1471,8 @@ impl GameHandler for Holdem {
                 if !self.is_acting_player(player_id) {
                     return Err(errors::not_the_acting_player());
                 }
+
+                self.reduce_time_cards(effect)?;
 
                 let Some(player) = self.player_map.get_mut(&player_id) else {
                     return Err(errors::internal_player_not_found());
@@ -1432,7 +1493,7 @@ impl GameHandler for Holdem {
                         )?;
                         self.next_state(effect)?;
                         return Ok(());
-                    } else {
+                    } else if street != Street::Preflop {
                         player.timeout += 1;
                     }
                 }

--- a/base/tests/helper.rs
+++ b/base/tests/helper.rs
@@ -43,27 +43,27 @@ pub fn gaming_players() -> BTreeMap<u64, Player> {
     BTreeMap::from([
         (
             ALICE,
-            Player::new_with_timeout_and_status(ALICE, 1000, 0usize, PlayerStatus::Acting),
+            Player::new_with_defaults(ALICE, 1000, 0usize, PlayerStatus::Acting),
         ),
         (
             BOB,
-            Player::new_with_timeout_and_status(BOB, 200, 1usize, PlayerStatus::Acted),
+            Player::new_with_defaults(BOB, 200, 1usize, PlayerStatus::Acted),
         ),
         (
             CAROL,
-            Player::new_with_timeout_and_status(CAROL, 0, 2usize, PlayerStatus::Allin),
+            Player::new_with_defaults(CAROL, 0, 2usize, PlayerStatus::Allin),
         ),
         (
             DAVE,
-            Player::new_with_timeout_and_status(DAVE, 780, 3usize, PlayerStatus::Acted),
+            Player::new_with_defaults(DAVE, 780, 3usize, PlayerStatus::Acted),
         ),
         (
             EVA,
-            Player::new_with_timeout_and_status(EVA, 650, 4usize, PlayerStatus::Acted),
+            Player::new_with_defaults(EVA, 650, 4usize, PlayerStatus::Acted),
         ),
         (
             FRANK,
-            Player::new_with_timeout_and_status(FRANK, 800, 5usize, PlayerStatus::Fold),
+            Player::new_with_defaults(FRANK, 800, 5usize, PlayerStatus::Fold),
         ),
     ])
 }

--- a/mtt-base/src/lib.rs
+++ b/mtt-base/src/lib.rs
@@ -1,32 +1,53 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use race_api::prelude::*;
 
+pub const DEFAULT_TIME_CARDS: u8 = 10;
+
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Default, PartialEq, Eq)]
 pub struct MttTablePlayer {
     pub id: u64,
     pub chips: u64,
     pub table_position: usize,
+    pub time_cards: u8,
+}
+
+impl MttTablePlayer {
+    pub fn new(id: u64, chips: u64, table_position: usize, time_cards: u8) -> Self {
+        Self {
+            id,
+            chips,
+            table_position,
+            time_cards,
+        }
+    }
+
+    /// Give time_cards a default value.
+    /// For testing
+    pub fn new_with_defaults(id: u64, chips: u64, table_position: usize) -> Self {
+        Self::new(id, chips, table_position, DEFAULT_TIME_CARDS)
+    }
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Default, PartialEq, Eq)]
 pub struct MttTableSitin {
     pub id: u64,
     pub chips: u64,
+    pub time_cards: u8,
 }
 
 impl MttTableSitin {
-    pub fn new(id: u64, chips: u64) -> Self {
-        Self { id, chips }
-    }
-}
-
-impl MttTablePlayer {
-    pub fn new(id: u64, chips: u64, table_position: usize) -> Self {
+    pub fn new(id: u64, chips: u64, time_cards: u8) -> Self {
         Self {
             id,
             chips,
-            table_position,
+            time_cards,
         }
+    }
+
+    /// Give time_cards a default value.
+    /// For testing
+    pub fn new_with_defaults(id: u64, chips: u64) -> Self {
+        Self::new(id, chips, DEFAULT_TIME_CARDS)
     }
 }
 
@@ -90,11 +111,12 @@ impl MttTableState {
                 }
             }
 
-            self.players.push(MttTablePlayer {
-                id: player.id,
-                chips: player.chips,
+            self.players.push(MttTablePlayer::new(
+                player.id,
+                player.chips,
                 table_position,
-            });
+                player.time_cards,
+            ));
             // Update relocated player's table position as well
             player.table_position = table_position;
 
@@ -125,9 +147,17 @@ pub struct PlayerResult {
 }
 
 impl PlayerResult {
-    pub fn new(player_id: u64, chips: u64, chips_change: Option<ChipsChange>, status: PlayerResultStatus) -> Self {
+    pub fn new(
+        player_id: u64,
+        chips: u64,
+        chips_change: Option<ChipsChange>,
+        status: PlayerResultStatus,
+    ) -> Self {
         Self {
-            player_id, chips, chips_change, status
+            player_id,
+            chips,
+            chips_change,
+            status,
         }
     }
 }

--- a/mtt-table/src/lib.rs
+++ b/mtt-table/src/lib.rs
@@ -123,6 +123,7 @@ impl MttTable {
                     p.id,
                     p.chips,
                     p.position as _,
+                    p.time_cards,
                 )
             })
             .collect();
@@ -169,15 +170,18 @@ impl MttTable {
                 let origin_num_of_players = self.holdem.player_map.len();
 
                 for sitin in sitins.into_iter() {
-                    let MttTableSitin { id, chips } = sitin;
+                    let MttTableSitin { id, chips, time_cards } = sitin;
 
                     if let Some(position) = self.holdem.find_position() {
                         match self.holdem.player_map.entry(id) {
-                            Entry::Vacant(e) => e.insert(Player::new_with_timeout_and_status(
+                            Entry::Vacant(e) => e.insert(Player::new(
                                 id,
                                 chips,
-                                position as usize,
+                                position as u16,
                                 PlayerStatus::Init,
+                                0,
+                                0,
+                                time_cards,
                             )),
                             Entry::Occupied(_) => {
                                 return Err(errors::duplicated_player_in_relocate())
@@ -216,7 +220,7 @@ mod tests {
     use race_holdem_mtt_base::{HoldemBridgeEvent, MttTablePlayer, MttTableState};
 
     fn default_players(num_of_players: usize) -> Vec<MttTablePlayer> {
-        (1..=num_of_players).map(|n| MttTablePlayer::new(n as u64, (n + 1) as u64 * 500, n - 1)).collect()
+        (1..=num_of_players).map(|n| MttTablePlayer::new_with_defaults(n as u64, (n + 1) as u64 * 500, n - 1)).collect()
     }
 
     fn default_mtt_table_state(num_of_players: usize) -> MttTableState {
@@ -248,8 +252,8 @@ mod tests {
             sb: 100,
             bb: 200,
             players: vec![
-                MttTablePlayer::new(1, 1000, 0),
-                MttTablePlayer::new(2, 1500, 1),
+                MttTablePlayer::new_with_defaults(1, 1000, 0),
+                MttTablePlayer::new_with_defaults(2, 1500, 1),
             ],
             table_id: 1,
             btn: 0,
@@ -311,7 +315,7 @@ mod tests {
         // Attempt to relocate the same player to the table
         let bridge_event = HoldemBridgeEvent::SitinPlayers {
             sitins: vec![
-                MttTableSitin::new(1, 1000), // Duplicate player
+                MttTableSitin::new_with_defaults(1, 1000), // Duplicate player
             ],
         };
 
@@ -329,7 +333,7 @@ mod tests {
         // Attempt to relocate a player to an already occupied position
         let bridge_event = HoldemBridgeEvent::SitinPlayers {
             sitins: vec![
-                MttTableSitin::new(3, 3000), // Player 3 is already on the table
+                MttTableSitin::new_with_defaults(3, 3000), // Player 3 is already on the table
             ],
         };
 
@@ -348,8 +352,8 @@ mod tests {
         let mut effect = Effect::default();
 
         let sitins = vec![
-            MttTableSitin::new(4, 1000),
-            MttTableSitin::new(5, 1500),
+            MttTableSitin::new_with_defaults(4, 1000),
+            MttTableSitin::new_with_defaults(5, 1500),
         ];
 
         let bridge_event = HoldemBridgeEvent::SitinPlayers { sitins };
@@ -371,7 +375,7 @@ mod tests {
         let mut effect = Effect::default();
 
         let sitins = vec![
-            MttTableSitin::new(1, 500),
+            MttTableSitin::new_with_defaults(1, 500),
         ];
 
         let bridge_event = HoldemBridgeEvent::SitinPlayers { sitins };
@@ -400,7 +404,7 @@ mod tests {
         let mut effect = Effect::default();
 
         let sitins = vec![
-            MttTableSitin::new(2, 500),
+            MttTableSitin::new_with_defaults(2, 500),
         ];
 
         let bridge_event = HoldemBridgeEvent::SitinPlayers { sitins };

--- a/mtt/src/tests/helper.rs
+++ b/mtt/src/tests/helper.rs
@@ -38,9 +38,10 @@ pub fn create_mtt_with_players(player_nums_per_table: &[usize], table_size: u8) 
                 PlayerRankStatus::Play,
                 rank_id as u16 % table_size as u16,
                 vec![start_chips],
+                DEFAULT_TIME_CARDS,
             ));
 
-            let player = MttTablePlayer::new(rank_id, start_chips, i);
+            let player = MttTablePlayer::new(rank_id, start_chips, i, DEFAULT_TIME_CARDS);
             table_state.players.push(player);
             mtt.table_assigns.insert(rank_id, table_id);
             rank_id += 1;

--- a/mtt/src/tests/misc.rs
+++ b/mtt/src/tests/misc.rs
@@ -16,17 +16,17 @@ fn test_sort_ranks_ensures_eliminated_players_keep_order() {
 
     // Active players
     mtt.ranks
-        .push(PlayerRank::new(1, 5000, PlayerRankStatus::Play, 0, vec![5000]));
+        .push(PlayerRank::new(1, 5000, PlayerRankStatus::Play, 0, vec![5000], DEFAULT_TIME_CARDS));
     mtt.ranks
-        .push(PlayerRank::new(2, 10000, PlayerRankStatus::Play, 1, vec![10000]));
+        .push(PlayerRank::new(2, 10000, PlayerRankStatus::Play, 1, vec![10000], DEFAULT_TIME_CARDS));
     mtt.ranks
-        .push(PlayerRank::new(3, 7000, PlayerRankStatus::Play, 2, vec![7000]));
+        .push(PlayerRank::new(3, 7000, PlayerRankStatus::Play, 2, vec![7000], DEFAULT_TIME_CARDS));
 
     // Eliminated players
     mtt.ranks
-        .push(PlayerRank::new(4, 0, PlayerRankStatus::Out, 3, vec![5000]));
+        .push(PlayerRank::new(4, 0, PlayerRankStatus::Out, 3, vec![5000], DEFAULT_TIME_CARDS));
     mtt.ranks
-        .push(PlayerRank::new(5, 0, PlayerRankStatus::Out, 4, vec![5000]));
+        .push(PlayerRank::new(5, 0, PlayerRankStatus::Out, 4, vec![5000], DEFAULT_TIME_CARDS));
 
     mtt.sort_ranks();
 
@@ -47,9 +47,9 @@ fn test_get_table_ids_with_least_most_players() {
                 MttTableState {
                     table_id: 1,
                     players: vec![
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(2, 10000, 1),
-                        MttTablePlayer::new(3, 10000, 2),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(2, 10000, 1),
+                        MttTablePlayer::new_with_defaults(3, 10000, 2),
                     ],
                     ..Default::default()
                 },
@@ -59,8 +59,8 @@ fn test_get_table_ids_with_least_most_players() {
                 MttTableState {
                     table_id: 2,
                     players: vec![
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(2, 10000, 1),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(2, 10000, 1),
                     ],
                     ..Default::default()
                 },
@@ -70,10 +70,10 @@ fn test_get_table_ids_with_least_most_players() {
                 MttTableState {
                     table_id: 3,
                     players: vec![
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(2, 10000, 1),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(2, 10000, 1),
                     ],
                     ..Default::default()
                 },
@@ -83,8 +83,8 @@ fn test_get_table_ids_with_least_most_players() {
                 MttTableState {
                     table_id: 4,
                     players: vec![
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(2, 10000, 1),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(2, 10000, 1),
                     ],
                     ..Default::default()
                 },
@@ -94,10 +94,10 @@ fn test_get_table_ids_with_least_most_players() {
                 MttTableState {
                     table_id: 5,
                     players: vec![
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(1, 10000, 0),
-                        MttTablePlayer::new(2, 10000, 1),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(1, 10000, 0),
+                        MttTablePlayer::new_with_defaults(2, 10000, 1),
                     ],
                     ..Default::default()
                 },

--- a/mtt/src/tests/test_handle_bounty.rs
+++ b/mtt/src/tests/test_handle_bounty.rs
@@ -10,8 +10,8 @@ fn test_handle_bounty_single_winner_divisible() {
         PlayerResult::new(1, 1000, Some(ChipsChange::Add(500)), PlayerResultStatus::Normal),
         PlayerResult::new(2, 0, Some(ChipsChange::Sub(500)), PlayerResultStatus::Eliminated),
     ];
-    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000]));
-    mtt.ranks.push(PlayerRank::new(2, 0, PlayerRankStatus::Out, 1, vec![1000]));
+    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000], DEFAULT_TIME_CARDS));
+    mtt.ranks.push(PlayerRank::new(2, 0, PlayerRankStatus::Out, 1, vec![1000], DEFAULT_TIME_CARDS));
     mtt.ranks[1].bounty_reward = 100;
     mtt.ranks[1].bounty_transfer = 200;
     mtt.handle_bounty(&player_results, &mut effect).unwrap();
@@ -30,8 +30,8 @@ fn test_handle_bounty_single_winner_non_divisible() {
         PlayerResult::new(1, 1000, Some(ChipsChange::Add(500)), PlayerResultStatus::Normal),
         PlayerResult::new(2, 0, Some(ChipsChange::Sub(500)), PlayerResultStatus::Eliminated),
     ];
-    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000]));
-    mtt.ranks.push(PlayerRank::new(2, 0, PlayerRankStatus::Out, 1, vec![1000]));
+    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000], DEFAULT_TIME_CARDS));
+    mtt.ranks.push(PlayerRank::new(2, 0, PlayerRankStatus::Out, 1, vec![1000], DEFAULT_TIME_CARDS));
     mtt.ranks[1].bounty_reward = 101;
     mtt.ranks[1].bounty_transfer = 203;
     mtt.handle_bounty(&player_results, &mut effect).unwrap();
@@ -54,9 +54,9 @@ fn test_handle_bounty_multiple_winners_divisible() {
         PlayerResult::new(2, 1000, Some(ChipsChange::Add(250)), PlayerResultStatus::Normal),
         PlayerResult::new(3, 0, Some(ChipsChange::Sub(500)), PlayerResultStatus::Eliminated),
     ];
-    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000]));
-    mtt.ranks.push(PlayerRank::new(2, 1000, PlayerRankStatus::Play, 1, vec![1000]));
-    mtt.ranks.push(PlayerRank::new(3, 0, PlayerRankStatus::Out, 2, vec![1000]));
+    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000], DEFAULT_TIME_CARDS));
+    mtt.ranks.push(PlayerRank::new(2, 1000, PlayerRankStatus::Play, 1, vec![1000], DEFAULT_TIME_CARDS));
+    mtt.ranks.push(PlayerRank::new(3, 0, PlayerRankStatus::Out, 2, vec![1000], DEFAULT_TIME_CARDS));
     mtt.ranks[2].bounty_reward = 100;
     mtt.ranks[2].bounty_transfer = 200;
     mtt.handle_bounty(&player_results, &mut effect).unwrap();
@@ -81,9 +81,9 @@ fn test_handle_bounty_multiple_winners_non_divisible() {
         PlayerResult::new(2, 1000, Some(ChipsChange::Add(250)), PlayerResultStatus::Normal),
         PlayerResult::new(3, 0, Some(ChipsChange::Sub(500)), PlayerResultStatus::Eliminated),
     ];
-    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000]));
-    mtt.ranks.push(PlayerRank::new(2, 1000, PlayerRankStatus::Play, 1, vec![1000]));
-    mtt.ranks.push(PlayerRank::new(3, 0, PlayerRankStatus::Out, 2, vec![1000]));
+    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000], DEFAULT_TIME_CARDS));
+    mtt.ranks.push(PlayerRank::new(2, 1000, PlayerRankStatus::Play, 1, vec![1000], DEFAULT_TIME_CARDS));
+    mtt.ranks.push(PlayerRank::new(3, 0, PlayerRankStatus::Out, 2, vec![1000], DEFAULT_TIME_CARDS));
     mtt.ranks[2].bounty_reward = 101;
     mtt.ranks[2].bounty_transfer = 203;
     mtt.handle_bounty(&player_results, &mut effect).unwrap();
@@ -113,8 +113,8 @@ fn test_handle_bounty_no_eliminated() {
         PlayerResult::new(1, 1000, Some(ChipsChange::Add(250)), PlayerResultStatus::Normal),
         PlayerResult::new(2, 1000, Some(ChipsChange::Add(250)), PlayerResultStatus::Normal),
     ];
-    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000]));
-    mtt.ranks.push(PlayerRank::new(2, 1000, PlayerRankStatus::Play, 1, vec![1000]));
+    mtt.ranks.push(PlayerRank::new(1, 1000, PlayerRankStatus::Play, 0, vec![1000], DEFAULT_TIME_CARDS));
+    mtt.ranks.push(PlayerRank::new(2, 1000, PlayerRankStatus::Play, 1, vec![1000], DEFAULT_TIME_CARDS));
     mtt.handle_bounty(&player_results, &mut effect).unwrap();
     assert_eq!(mtt.ranks[0].bounty_reward, 0);
     assert_eq!(mtt.ranks[1].bounty_reward, 0);

--- a/mtt/src/tests/test_handle_game_result.rs
+++ b/mtt/src/tests/test_handle_game_result.rs
@@ -30,7 +30,7 @@ fn test_game_result_given_3_tables_and_current_table_has_1_player_do_dispatch_no
         table: MttTableState {
             hand_id: 1,
             table_id: 3,
-            players: vec![MttTablePlayer::new(8, 20000, 1)],
+            players: vec![MttTablePlayer::new_with_defaults(8, 20000, 1)],
             next_game_start: 0,
             ..Default::default()
         },
@@ -74,7 +74,7 @@ fn test_game_result_given_2_tables_and_current_table_has_1_player_do_dispatch_no
         table: MttTableState {
             hand_id: 1,
             table_id: 2,
-            players: vec![MttTablePlayer::new(5, 20000, 1)],
+            players: vec![MttTablePlayer::new_with_defaults(5, 20000, 1)],
             next_game_start: 0,
             ..Default::default()
         },
@@ -108,9 +108,9 @@ fn test_game_result_given_3_tables_and_single_player_in_different_table_do_dispa
             hand_id: 1,
             table_id: 2,
             players: vec![
-                MttTablePlayer::new(4, 10000, 0),
-                MttTablePlayer::new(5, 10000, 1),
-                MttTablePlayer::new(6, 10000, 2),
+                MttTablePlayer::new_with_defaults(4, 10000, 0),
+                MttTablePlayer::new_with_defaults(5, 10000, 1),
+                MttTablePlayer::new_with_defaults(6, 10000, 2),
             ],
             ..Default::default()
         },
@@ -139,7 +139,7 @@ fn test_game_result_given_3_tables_and_single_player_in_different_table_do_dispa
         ),(
             3,
             HoldemBridgeEvent::SitinPlayers {
-                sitins: vec![MttTableSitin::new(4, 10000)]
+                sitins: vec![MttTableSitin::new_with_defaults(4, 10000)]
             }
         )]
     );
@@ -176,8 +176,8 @@ fn test_game_result_given_3_tables_do_close_table() {
             hand_id: 1,
             table_id: 1,
             players: vec![
-                MttTablePlayer::new(1, 20000, 0),
-                MttTablePlayer::new(3, 10000, 2),
+                MttTablePlayer::new_with_defaults(1, 20000, 0),
+                MttTablePlayer::new_with_defaults(3, 10000, 2),
             ],
             ..Default::default()
         },
@@ -207,7 +207,10 @@ fn test_game_result_given_3_tables_do_close_table() {
             (
                 3,
                 HoldemBridgeEvent::SitinPlayers {
-                    sitins: vec![MttTableSitin::new(1, 20000), MttTableSitin::new(3, 10000),],
+                    sitins: vec![
+                        MttTableSitin::new_with_defaults(1, 20000),
+                        MttTableSitin::new_with_defaults(3, 10000),
+                    ],
                 }
             )
         ]
@@ -243,7 +246,7 @@ fn test_game_result_given_2_tables_do_close_table() {
         table: MttTableState {
             hand_id: 1,
             table_id: 1,
-            players: vec![MttTablePlayer::new(1, 20000, 0)],
+            players: vec![MttTablePlayer::new_with_defaults(1, 20000, 0)],
             ..Default::default()
         },
     };
@@ -267,7 +270,7 @@ fn test_game_result_given_2_tables_do_close_table() {
             (
                 2,
                 HoldemBridgeEvent::SitinPlayers {
-                    sitins: vec![MttTableSitin::new(1, 20000),]
+                    sitins: vec![MttTableSitin::new_with_defaults(1, 20000),]
                 }
             )
         ]
@@ -288,9 +291,9 @@ fn test_game_result_given_2_tables_move_one_player() {
             hand_id: 1,
             table_id: 1,
             players: vec![
-                MttTablePlayer::new(1, 10000, 0),
-                MttTablePlayer::new(2, 10000, 1),
-                MttTablePlayer::new(3, 10000, 2),
+                MttTablePlayer::new_with_defaults(1, 10000, 0),
+                MttTablePlayer::new_with_defaults(2, 10000, 1),
+                MttTablePlayer::new_with_defaults(3, 10000, 2),
             ],
             ..Default::default()
         },
@@ -318,7 +321,7 @@ fn test_game_result_given_2_tables_move_one_player() {
             (
                 2,
                 HoldemBridgeEvent::SitinPlayers {
-                    sitins: vec![MttTableSitin::new(1, 10000)]
+                    sitins: vec![MttTableSitin::new_with_defaults(1, 10000)]
                 }
             )
         ]
@@ -350,9 +353,9 @@ fn test_game_result_no_op_when_players_are_moving() {
             hand_id: 1,
             table_id: 1,
             players: vec![
-                MttTablePlayer::new(1, 10000, 0),
-                MttTablePlayer::new(2, 10000, 1),
-                MttTablePlayer::new(3, 10000, 2),
+                MttTablePlayer::new_with_defaults(1, 10000, 0),
+                MttTablePlayer::new_with_defaults(2, 10000, 1),
+                MttTablePlayer::new_with_defaults(3, 10000, 2),
             ],
             ..Default::default()
         },
@@ -388,21 +391,25 @@ fn test_game_result_given_moving_player_sitted_do_no_balance_table() {
     let mut mtt = helper::create_mtt_with_players(&[2, 4], 4);
     let mut effect = Effect::default();
 
-    // Simulate a player is already in the process of moving from table 1 to table 2
+    // Simulate a player is already in the process of moving from table 2 to table 1
     mtt.table_assigns_pending.insert(3, 1);
 
     // Trigger a GameResult event from table 1
     let game_result = HoldemBridgeEvent::GameResult {
         hand_id: 1,
         table_id: 1,
-        player_results: vec![],
+        player_results: vec![
+            PlayerResult::new(1, 10000, None, PlayerResultStatus::Normal),
+            PlayerResult::new(2, 10000, None, PlayerResultStatus::Normal),
+            PlayerResult::new(3, 10000, None, PlayerResultStatus::Normal),
+        ],
         table: MttTableState {
             hand_id: 1,
             table_id: 1,
             players: vec![
-                MttTablePlayer::new(1, 10000, 0),
-                MttTablePlayer::new(2, 10000, 1),
-                MttTablePlayer::new(3, 10000, 2),
+                MttTablePlayer::new_with_defaults(1, 10000, 0),
+                MttTablePlayer::new_with_defaults(2, 10000, 1),
+                MttTablePlayer::new_with_defaults(3, 10000, 2),
             ],
             ..Default::default()
         },
@@ -427,6 +434,8 @@ fn test_game_result_given_moving_player_sitted_do_no_balance_table() {
         }
     )]);
 
+    println!("{:?}", mtt.table_assigns_pending);
+
     assert!(mtt.table_assigns_pending.is_empty());
     assert_eq!(mtt.table_assigns.get(&3), Some(&1));
     assert_eq!(mtt.tables.get(&1).unwrap().players.len(), 3);
@@ -438,23 +447,29 @@ fn test_game_result_given_moving_player_sitted_do_balance_table() {
     let mut mtt = helper::create_mtt_with_players(&[4, 2], 6);
     let mut effect = Effect::default();
 
-    // Simulate a player is already in the process of moving from table 1 to table 2
+    // Simulate a player is already in the process of moving from table 2 to table 1
     mtt.table_assigns_pending.insert(5, 1);
 
     // Trigger a GameResult event from table 1
     let game_result = HoldemBridgeEvent::GameResult {
         hand_id: 1,
         table_id: 1,
-        player_results: vec![],
+        player_results: vec![
+            PlayerResult::new(1, 10000, None, PlayerResultStatus::Normal),
+            PlayerResult::new(2, 10000, None, PlayerResultStatus::Normal),
+            PlayerResult::new(3, 10000, None, PlayerResultStatus::Normal),
+            PlayerResult::new(4, 10000, None, PlayerResultStatus::Normal),
+            PlayerResult::new(5, 10000, None, PlayerResultStatus::Normal),
+        ],
         table: MttTableState {
             hand_id: 1,
             table_id: 1,
             players: vec![
-                MttTablePlayer::new(1, 10000, 0),
-                MttTablePlayer::new(2, 10000, 1),
-                MttTablePlayer::new(3, 10000, 2),
-                MttTablePlayer::new(4, 10000, 2),
-                MttTablePlayer::new(5, 10000, 2),
+                MttTablePlayer::new_with_defaults(1, 10000, 0),
+                MttTablePlayer::new_with_defaults(2, 10000, 1),
+                MttTablePlayer::new_with_defaults(3, 10000, 2),
+                MttTablePlayer::new_with_defaults(4, 10000, 2),
+                MttTablePlayer::new_with_defaults(5, 10000, 2),
             ],
             ..Default::default()
         },
@@ -481,7 +496,7 @@ fn test_game_result_given_moving_player_sitted_do_balance_table() {
         ),(
             2,
             HoldemBridgeEvent::SitinPlayers {
-                sitins: vec![MttTableSitin::new(1, 10000)]
+                sitins: vec![MttTableSitin::new_with_defaults(1, 10000)]
             }
         )
     ]);

--- a/mtt/src/tests/test_sit_players.rs
+++ b/mtt/src/tests/test_sit_players.rs
@@ -9,6 +9,7 @@ fn add_player_to_mtt(mtt: &mut Mtt) -> u64 {
         PlayerRankStatus::Pending,
         l as u16,
         vec![1000],
+        DEFAULT_TIME_CARDS,
     ));
     return player_id;
 }
@@ -43,7 +44,7 @@ fn sit_players_given_two_table_with_one_player_do_sit_to_non_empty_table() {
         vec![(
             1,
             HoldemBridgeEvent::SitinPlayers {
-                sitins: vec![MttTableSitin::new(pid, 1000)]
+                sitins: vec![MttTableSitin::new_with_defaults(pid, 1000)]
             }
         )]
     );
@@ -65,7 +66,7 @@ fn sit_players_given_two_table_with_one_player_do_sit_to_non_empty_table_2() {
         vec![(
             2,
             HoldemBridgeEvent::SitinPlayers {
-                sitins: vec![MttTableSitin::new(pid, 1000)]
+                sitins: vec![MttTableSitin::new_with_defaults(pid, 1000)]
             }
         )]
     );
@@ -84,7 +85,7 @@ fn sit_multiple_players_when_all_tables_are_full_creates_new_tables() {
     effect.print_logs();
 
     let (sb, bb) = mtt.calc_blinds().unwrap();
-    let table_created = MttTableState::new(0, sb, bb, vec![MttTablePlayer::new(10, 1000, 0), MttTablePlayer::new(11, 1000, 1)]);
+    let table_created = MttTableState::new(0, sb, bb, vec![MttTablePlayer::new_with_defaults(10, 1000, 0), MttTablePlayer::new_with_defaults(11, 1000, 1)]);
     assert_eq!(
         effect.launch_sub_games,
         vec![
@@ -111,13 +112,13 @@ fn sit_multiple_players_with_empty_tables_should_fill_sparse_tables() {
             (
                 1,
                 HoldemBridgeEvent::SitinPlayers {
-                    sitins: vec![MttTableSitin::new(pid2, 1000)]
+                    sitins: vec![MttTableSitin::new_with_defaults(pid2, 1000)]
                 }
             ),
             (
                 2,
                 HoldemBridgeEvent::SitinPlayers {
-                    sitins: vec![MttTableSitin::new(pid1, 1000)]
+                    sitins: vec![MttTableSitin::new_with_defaults(pid1, 1000)]
                 }
             )
         ]
@@ -173,10 +174,10 @@ fn sit_players_in_existing_and_new_tables() {
 
     let (sb, bb) = mtt.calc_blinds().unwrap();
     let table_created = MttTableState::new(0, sb, bb, vec![
-        MttTablePlayer::new(13, 1000, 0),
-        MttTablePlayer::new(14, 1000, 1),
-        MttTablePlayer::new(15, 1000, 2),
-        MttTablePlayer::new(16, 1000, 3),
+        MttTablePlayer::new_with_defaults(13, 1000, 0),
+        MttTablePlayer::new_with_defaults(14, 1000, 1),
+        MttTablePlayer::new_with_defaults(15, 1000, 2),
+        MttTablePlayer::new_with_defaults(16, 1000, 3),
     ]);
 
     assert_eq!(effect.launch_sub_games, vec![
@@ -186,16 +187,16 @@ fn sit_players_in_existing_and_new_tables() {
     assert_eq!(effect.list_bridge_events().unwrap(), vec![
         (1, HoldemBridgeEvent::SitinPlayers {
             sitins: vec![
-                MttTableSitin::new(7, 1000),
-                MttTableSitin::new(8, 1000),
-                MttTableSitin::new(9, 1000),
-                MttTableSitin::new(11, 1000),
+                MttTableSitin::new_with_defaults(7, 1000),
+                MttTableSitin::new_with_defaults(8, 1000),
+                MttTableSitin::new_with_defaults(9, 1000),
+                MttTableSitin::new_with_defaults(11, 1000),
             ]
         }),
         (2, HoldemBridgeEvent::SitinPlayers {
             sitins: vec![
-                MttTableSitin::new(10, 1000),
-                MttTableSitin::new(12, 1000),
+                MttTableSitin::new_with_defaults(10, 1000),
+                MttTableSitin::new_with_defaults(12, 1000),
             ]
         }),
     ]);


### PR DESCRIPTION
Add time bank to base module.

Each player has 5 time cards by default when they join.

Each time card gives the user extra 30 seconds action time.